### PR TITLE
Finalize already verifies the signature

### DIFF
--- a/draft-wood-cfrg-rsa-blind-signatures.md
+++ b/draft-wood-cfrg-rsa-blind-signatures.md
@@ -161,7 +161,8 @@ The core issuance protocol runs as follows:
 
 Upon completion, correctness requires that clients can verify signature `sig` over private
 input message `msg` using the server public key `pkS` by invoking the RSASSA-PSS-VERIFY
-routine defined in {{!RFC3447}}.
+routine defined in {{!RFC3447}}. The finalization function performs that check before
+returning the signature.
 
 # RSABSSA Signature Instantiation
 


### PR DESCRIPTION
The overview suggests that clients have to verify the signature returned by the finalization function.

Clarify that this is not necessary, as it is already done by the finalization function before returning.

This is obvious when directly implementing the protocol, but it may be way less obvious when using higher-level APIs.