### PR TITLE
Rename and redefine `random_integer`

### DIFF
--- a/draft-wood-cfrg-rsa-blind-signatures.md
+++ b/draft-wood-cfrg-rsa-blind-signatures.md
@@ -145,8 +145,8 @@ protocol operations in this document:
 - I2OSP and OS2IP: Convert a byte string to and from a non-negative integer as
   described in {{!RFC8017}}. Note that these functions operate on byte strings
   in big-endian byte order.
-- random_integer(M, N): Generate a random, uniformly distributed integer R
-  such that M < R <= N.
+- random_integer_uniform(M, N): Generate a random, uniformly distributed integer R
+  such that M <= R < N.
 - inverse_mod(n, p): Compute the multiplicative inverse of n mod p where p is prime.
 - len(s): The length of a byte string, in octets.
 
@@ -225,7 +225,7 @@ Steps:
 1. encoded_message = EMSA-PSS-ENCODE(msg, kBits - 1) with MGF and HF as defined in the parameters
 2. If EMSA-PSS-ENCODE raises an error, raise the error and stop
 3. m = OS2IP(encoded_message)
-4. r = random_integer(0, n - 1)
+4. r = random_integer_uniform(1, n)
 5. x = RSAVP1(pkS, r)
 6. z = m * x mod n
 7. r_inv = inverse_mod(r, n)

--- a/poc/rsabssa.sage
+++ b/poc/rsabssa.sage
@@ -90,7 +90,7 @@ def hasher(x, l):
     assert(l <= 32)
     return int.from_bytes(SHA256.new(data=x).digest()[0:l], 'big')
 
-def random_integer(m, n):
+def random_integer_uniform(m, n):
     return getRandomRange(m, n) # numpy.random.randint(m, n)
 
 def random_bytes(n):
@@ -162,7 +162,7 @@ def rsassa_pss_sign_blind(pkS, msg_hash):
     encoded_message = rsassa_pss_sign_encode(pkS.n, msg_hash)
     m = OS2IP(encoded_message)
 
-    r = random_integer(1, pkS.n - 1)
+    r = random_integer_uniform(1, pkS.n)
     r_inv = inverse_mod(r, pkS.n)
     assert((r * r_inv) % pkS.n == 1)
 


### PR DESCRIPTION
Rename `random_integer()` to `random_integer_uniform()` to emphasize the fact that is has to be uniformly distributed.
    
Also slightly change its definition to match most off the shelf implementations, including the one we define in the PoC. Fix the upper bound in the PoC by the way.